### PR TITLE
Add repository metadata automation and release publishing

### DIFF
--- a/.github/workflows/build-mac-dmg.yml
+++ b/.github/workflows/build-mac-dmg.yml
@@ -3,13 +3,15 @@ name: Build Mac DMG
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:
   build-mac:
     runs-on: macos-14  # Apple Silicon runner for aarch64
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -38,8 +40,15 @@ jobs:
         env:
           CI: true
 
-      - name: Upload DMG
+      - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:
           name: AssistMem-macOS-aarch64
-          path: src-tauri/target/release/bundle/macos/*.dmg
+          path: src-tauri/target/release/bundle/dmg/*.dmg
+
+      - name: Publish GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: src-tauri/target/release/bundle/dmg/*.dmg
+          generate_release_notes: true

--- a/.github/workflows/update-about.yml
+++ b/.github/workflows/update-about.yml
@@ -1,0 +1,33 @@
+name: Update Repository About
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  update-about:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Update repository description and topics
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api --method PATCH /repos/${{ github.repository }} \
+            -f description="Local indexer and keyword search for chat history from Cursor IDE, Copilot, Claude Code, Codex, and Gemini CLI. No login." \
+            -f homepage="https://github.com/dishangyijiao/assistmem"
+
+          gh api --method PUT /repos/${{ github.repository }}/topics \
+            -f "names[]=cursor" \
+            -f "names[]=copilot" \
+            -f "names[]=claude-code" \
+            -f "names[]=codex" \
+            -f "names[]=gemini" \
+            -f "names[]=chat-history" \
+            -f "names[]=full-text-search" \
+            -f "names[]=sqlite" \
+            -f "names[]=tauri" \
+            -H "Accept: application/vnd.github.mercy-preview+json"


### PR DESCRIPTION
## Summary
This PR adds GitHub Actions workflows to automate repository metadata management and enable automated release publishing for macOS builds.

## Key Changes
- **New workflow: Update Repository About** (`update-about.yml`)
  - Automatically updates repository description and homepage on pushes to main
  - Sets repository topics for better discoverability (cursor, copilot, claude-code, codex, gemini, chat-history, full-text-search, sqlite, tauri)

- **Enhanced Mac DMG build workflow** (`build-mac-dmg.yml`)
  - Added tag-based triggering (`v*` tags) to enable release builds
  - Upgraded permissions from `contents: read` to `contents: write` to support release creation
  - Fixed artifact upload path from `macos/` to `dmg/` directory
  - Added automated GitHub Release publishing step that:
    - Triggers only on version tags
    - Uploads built DMG files as release assets
    - Auto-generates release notes from commits

## Implementation Details
- The update-about workflow runs on every push to main and can be manually triggered
- The build-mac workflow now supports both continuous integration (main branch) and release workflows (version tags)
- Release publishing uses `softprops/action-gh-release@v2` for reliable asset management

https://claude.ai/code/session_01Yc3A8nnNEDEEzsiUW4kyqm