### PR TITLE
Refactor GitHub release workflow to separate creation and asset upload

### DIFF
--- a/.github/workflows/build-mac-dmg.yml
+++ b/.github/workflows/build-mac-dmg.yml
@@ -8,7 +8,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  create-release:
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}
+
   build-mac:
+    needs: [create-release]
+    if: always() && (needs.create-release.result == 'success' || needs.create-release.result == 'skipped')
     runs-on: macos-14  # Apple Silicon runner for aarch64
     permissions:
       contents: write
@@ -46,9 +61,9 @@ jobs:
           name: AssistMem-macOS-aarch64
           path: src-tauri/target/release/bundle/dmg/*.dmg
 
-      - name: Publish GitHub Release
+      - name: Attach DMG to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           files: src-tauri/target/release/bundle/dmg/*.dmg
-          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, 'beta') || contains(github.ref, 'alpha') || contains(github.ref, 'rc') }}

--- a/.github/workflows/update-about.yml
+++ b/.github/workflows/update-about.yml
@@ -9,7 +9,7 @@ jobs:
   update-about:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      administration: write
 
     steps:
       - name: Update repository description and topics


### PR DESCRIPTION
## Summary
This PR refactors the macOS DMG build workflow to separate GitHub release creation from asset uploads, improving workflow reliability and clarity.

## Key Changes
- **New `create-release` job**: Dedicated job that creates GitHub releases when tags are pushed, with automatic release notes generation
  - Runs only on tag pushes (`refs/tags/`)
  - Automatically marks releases as prerelease if tag contains `beta`, `alpha`, or `rc`
  
- **Updated `build-mac` job**: Now depends on the `create-release` job
  - Added conditional logic to proceed if release creation succeeds or is skipped (non-tag pushes)
  - Renamed "Publish GitHub Release" step to "Attach DMG to GitHub Release" to clarify its purpose
  - Removed duplicate `generate_release_notes` from the asset upload step (now handled by `create-release`)
  - Maintains prerelease logic in the asset upload step for consistency

- **Fixed `update-about` workflow**: Corrected permissions from `contents: read` to `administration: write` to properly support repository description and topics updates

## Implementation Details
The workflow now follows a two-stage release process:
1. Release creation happens once per tag in the dedicated job
2. Asset attachment happens during the build, with proper dependency chaining to ensure the release exists before uploading files
3. The `if: always()` condition on `build-mac` ensures the job runs regardless of `create-release` outcome, while the additional condition checks that either the release was created successfully or the job was skipped (for non-tag builds)

https://claude.ai/code/session_017Kht7xUS7LfvgUeEAhVNFs