### PR TITLE
fix: window cannot be dragged after DMG installation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,15 +4,29 @@ import SessionPage from "./pages/SessionPage";
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<SearchPage />}>
-        <Route index element={<></>} />
-        <Route path="settings" element={<></>} />
-      </Route>
-      <Route path="/session" element={<SessionPage />} />
-      <Route path="/advanced" element={<Navigate to="/settings" replace />} />
-      <Route path="/integrations" element={<Navigate to="/settings" replace />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+    <>
+      {/* Real DOM element for Tauri overlay title bar drag region.
+          A CSS pseudo-element (::before) is not reliable in WKWebView;
+          a real element with data-tauri-drag-region is required. */}
+      <div data-tauri-drag-region style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: 28,
+        zIndex: 9999,
+        pointerEvents: "auto",
+      }} />
+      <Routes>
+        <Route path="/" element={<SearchPage />}>
+          <Route index element={<></>} />
+          <Route path="settings" element={<></>} />
+        </Route>
+        <Route path="/session" element={<SessionPage />} />
+        <Route path="/advanced" element={<Navigate to="/settings" replace />} />
+        <Route path="/integrations" element={<Navigate to="/settings" replace />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </>
   );
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -37,18 +37,6 @@ body,
   padding-top: 28px;
 }
 
-/* Unified drag region for overlay title bar across all pages */
-body::before {
-  content: "";
-  display: block;
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 28px;
-  -webkit-app-region: drag;
-  z-index: 1000;
-}
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
     "main"
   ],
   "permissions": [
-    "core:default"
+    "core:default",
+    "window:allow-start-dragging"
   ]
 }


### PR DESCRIPTION
## Problem

Fixes #31

After installing the DMG, users could not drag the app window. The root cause: `titleBarStyle: "Overlay"` removes the native title bar, requiring a custom drag region. The previous implementation used a `body::before` CSS pseudo-element with `-webkit-app-region: drag`, which is unreliable in WKWebView (Tauri's renderer on macOS).

## Changes

- *`frontend/src/App.tsx`*: Add a real `<div data-tauri-drag-region>` element fixed to the top 28px of the window. Real DOM elements work reliably in WKWebView; pseudo-elements do not.
- *`frontend/src/styles/global.css`*: Remove the broken `body::before` pseudo-element approach.
- *`src-tauri/capabilities/default.json`*: Add `window:allow-start-dragging` permission required by Tauri 2 for drag to function.

## Test plan

- [ ] Build DMG and install
- [ ] Verify window can be dragged from the top toolbar area
- [ ] Verify buttons/inputs in the top area still respond to clicks (pointerEvents not blocked)