### PR TITLE
fix: use strict equality in claudeDesktopDetect

### DIFF
--- a/server/integrations/client-config.ts
+++ b/server/integrations/client-config.ts
@@ -44,7 +44,7 @@ function writeJsonConfig(path: string, data: Record<string, unknown>): void {
 function claudeDesktopDetect(): boolean {
   const config = readJsonConfig(claudeDesktopConfigPath());
   const servers = config.mcpServers as Record<string, unknown> | undefined;
-  return servers != null && ASSISTMEM_SERVER_KEY in servers;
+  return servers !== null && servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
 }
 
 function claudeDesktopInstall(): void {


### PR DESCRIPTION
## Problem

The \`claudeDesktopDetect\` function in \`server/integrations/client-config.ts\` uses loose inequality (\`!= null\`), causing the ESLint \`eqeqeq\` rule to fail:

\`\`\`
47:18  error  Expected '!==' and instead saw '!='  eqeqeq
\`\`\`

This makes \`npm run lint\` exit non-zero, blocking CI.

## Root Cause

\`servers != null\` uses JavaScript's loose equality, which the project's ESLint config (\`eqeqeq: ["error", "always"]\`) disallows. The rule requires strict \`===\`/\`!==\` everywhere.

## Fix

Replace \`servers != null\` with \`servers !== null && servers !== undefined\`.

This is semantically equivalent — the loose \`!= null\` check catches both \`null\` and \`undefined\`; the strict version makes both checks explicit. The result preserves the runtime guard that prevents the \`in\` operator from receiving a non-object right-hand side.

## Verification

\`\`\`
npm run lint      ✓  0 errors
npm run typecheck ✓  no errors
npm test          ✓  400/400 pass
npm run build     ✓  build succeeded
\`\`\`

## Potential Risks / Side Effects

None. The change is a one-line equality rewrite with identical runtime semantics. No logic paths, types, or observable behaviour are altered.

---
*Auto-generated by the AssistMem bug inspector. Note: a previous PR (#42) for this same fix was closed without merging on 2026-03-24; the lint error persists on \`main\`.*