### PR TITLE
fix: use strict equality for null/undefined check in claudeDesktopDetect

### DIFF
--- a/server/integrations/client-config.ts
+++ b/server/integrations/client-config.ts
@@ -44,7 +44,7 @@ function writeJsonConfig(path: string, data: Record<string, unknown>): void {
 function claudeDesktopDetect(): boolean {
   const config = readJsonConfig(claudeDesktopConfigPath());
   const servers = config.mcpServers as Record<string, unknown> | undefined;
-  return servers != null && ASSISTMEM_SERVER_KEY in servers;
+  return servers !== null && servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
 }
 
 function claudeDesktopInstall(): void {


### PR DESCRIPTION
## Problem

`npm run lint` fails with:

```
server/integrations/client-config.ts
  47:18  error  Expected '!==' and instead saw '!='  eqeqeq
```

The project's ESLint config enforces `eqeqeq: ["error", "always"]` — loose equality (`!=`) is not allowed anywhere.

## Root Cause

`claudeDesktopDetect()` used `servers != null` (loose null check) on line 47. This coercively tests for both `null` and `undefined`, but the `eqeqeq` rule requires strict comparisons. Additionally, naively replacing it with only `!== null` would introduce a runtime `TypeError` when `servers` is `undefined` (key absent from parsed JSON), because the `in` operator throws on non-objects.

## The Fix

Replace the single loose check with two explicit strict comparisons:

```ts
// Before
return servers != null && ASSISTMEM_SERVER_KEY in servers;

// After
return servers !== null && servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
```

This is semantically identical to the original intent, satisfies `eqeqeq: always`, and is safe against both `null` (explicit JSON null) and `undefined` (missing key).

## Verification

```
npm run lint      → no errors
npm run typecheck → no errors
npm test          → 400 pass, 0 fail
```

## Potential Risks / Side Effects

None. The runtime behavior is identical to the original `!= null` guard. Only the syntax changes.