### PR TITLE
fix: return HTTP 500 (not 200) when MCP test fails

### DIFF
--- a/server/http/routes/integrations.ts
+++ b/server/http/routes/integrations.ts
@@ -150,6 +150,6 @@ export async function handleMcpTest(_req: IncomingMessage, res: ServerResponse):
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Test failed";
-    sendJson(res, 200, { ok: false, message });
+    sendError(res, 500, "MCP_TEST_FAILED", message);
   }
 }

--- a/server/integrations/client-config.ts
+++ b/server/integrations/client-config.ts
@@ -44,7 +44,7 @@ function writeJsonConfig(path: string, data: Record<string, unknown>): void {
 function claudeDesktopDetect(): boolean {
   const config = readJsonConfig(claudeDesktopConfigPath());
   const servers = config.mcpServers as Record<string, unknown> | undefined;
-  return servers != null && ASSISTMEM_SERVER_KEY in servers;
+  return servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
 }
 
 function claudeDesktopInstall(): void {


### PR DESCRIPTION
## Problem

`handleMcpTest` in `server/http/routes/integrations.ts` returns **HTTP 200** even when an error is caught, with the payload `{ ok: false, message }`. HTTP clients and proxies that only inspect the status code will treat this as a success.

## Root Cause

The catch branch used `sendJson(res, 200, { ok: false, message })` instead of the `sendError()` helper that all other error paths in this file use.

## The Fix

Changed line 153 to:
```ts
sendError(res, 500, "MCP_TEST_FAILED", message);
```

This matches the established pattern throughout `integrations.ts` (e.g. `INSTALL_FAILED` → 500, `REMOVE_FAILED` → 500) and correctly signals failure to callers.

Also fixed the pre-existing `eqeqeq` lint violation in `client-config.ts:47` (`!= null` → `!== undefined`) that was already causing `npm run lint` to exit with code 1 on `main`. This was needed so all CI checks pass on this PR.

## Verification

```
npm run typecheck  → clean (0 errors)
npm run lint       → clean (0 errors)
npm test           → 400 passed, 0 failed
npm run build      → success
```

## Potential Risks / Side Effects

The `handleMcpTest` endpoint is used by the frontend "Test Connection" button. Any frontend code that relied on inspecting `ok: false` in the JSON body still works — `sendError` still returns JSON with an `error.message` field. The only observable change is the HTTP status code going from 200 to 500 on failure, which is the correct behavior.