### PR TITLE
fix: use strict equality for null check in claudeDesktopDetect

### DIFF
--- a/server/integrations/client-config.ts
+++ b/server/integrations/client-config.ts
@@ -44,7 +44,7 @@ function writeJsonConfig(path: string, data: Record<string, unknown>): void {
 function claudeDesktopDetect(): boolean {
   const config = readJsonConfig(claudeDesktopConfigPath());
   const servers = config.mcpServers as Record<string, unknown> | undefined;
-  return servers != null && ASSISTMEM_SERVER_KEY in servers;
+  return servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
 }
 
 function claudeDesktopInstall(): void {


### PR DESCRIPTION
## Problem

`npm run lint` fails with 1 error:

```
/workspace/extra/assistmem/server/integrations/client-config.ts
  47:18  error  Expected '!==' and instead saw '!='  eqeqeq
```

The ESLint rule `eqeqeq: ["error", "always"]` (no null exception) requires strict equality in all comparisons.

## Root cause

In `claudeDesktopDetect()`, the `servers` variable is compared using loose inequality (`!= null`) rather than strict inequality. The type of `servers` is `Record<string, unknown> | undefined`, so `null` is not a member of the type — the correct strict check is `!== undefined`.

```ts
// Before
return servers != null && ASSISTMEM_SERVER_KEY in servers;

// After
return servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
```

## The fix

Single-character change on line 47 of `server/integrations/client-config.ts`: replace `!= null` with `!== undefined`. This preserves the same runtime behaviour for all values the type allows while satisfying the lint rule.

## Verification

```
npm run lint       ✅  0 errors
npm run typecheck  ✅  no errors
npm test           ✅  400/400 tests pass
npm run build      ✅  build succeeds
```

## Potential risks / side effects

None — the change is constrained to a single boolean expression. The only values `servers` can hold at runtime are `undefined` (key absent) or a `Record<string, unknown>` object (key present), so the logical outcome is identical.

> Note: a previous PR (#41) with the same fix was closed without merging. This PR recreates it from the current `main` tip.