### PR TITLE
fix: use strict equality for null check in claudeDesktopDetect

### DIFF
--- a/server/integrations/client-config.ts
+++ b/server/integrations/client-config.ts
@@ -44,7 +44,7 @@ function writeJsonConfig(path: string, data: Record<string, unknown>): void {
 function claudeDesktopDetect(): boolean {
   const config = readJsonConfig(claudeDesktopConfigPath());
   const servers = config.mcpServers as Record<string, unknown> | undefined;
-  return servers != null && ASSISTMEM_SERVER_KEY in servers;
+  return servers !== null && servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
 }
 
 function claudeDesktopInstall(): void {


### PR DESCRIPTION
## Problem

`npm run lint` fails with:

```
server/integrations/client-config.ts
  47:18  error  Expected '!==' and instead saw '!='  eqeqeq
```

The project enforces `eqeqeq: ["error", "always"]` in `eslint.config.js`, so this is a hard build/CI blocker.

## Root Cause

Line 47 of `server/integrations/client-config.ts` uses the loose inequality operator `!=` to check for `null`:

```ts
return servers != null && ASSISTMEM_SERVER_KEY in servers;
```

`servers` is typed as `Record<string, unknown> | undefined` (and could be `null` at runtime if JSON had `"mcpServers": null`). The loose `!=` coerces both `null` and `undefined` into a single check, but ESLint's `eqeqeq` rule with `"always"` does not allow this.

## Fix

Replace the loose check with two explicit strict comparisons:

```ts
return servers !== null && servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
```

This is semantically equivalent — both `null` and `undefined` are excluded — while satisfying the strict-equality requirement.

## Verification

All checks pass after the fix:

- `npm run typecheck` — ✅ no errors
- `npm run lint` — ✅ no errors
- `npm test` — ✅ 400/400 tests pass
- `npm run build` — ✅ build succeeds

## Potential Risks / Side Effects

- Behaviorally identical to the original loose check — no functional change.
- Affects only the `claudeDesktopDetect` function, which checks whether the MCP server key is present in Claude Desktop's config file.