### PR TITLE
fix: use strict equality check in claudeDesktopDetect

### DIFF
--- a/server/integrations/client-config.ts
+++ b/server/integrations/client-config.ts
@@ -44,7 +44,7 @@ function writeJsonConfig(path: string, data: Record<string, unknown>): void {
 function claudeDesktopDetect(): boolean {
   const config = readJsonConfig(claudeDesktopConfigPath());
   const servers = config.mcpServers as Record<string, unknown> | undefined;
-  return servers != null && ASSISTMEM_SERVER_KEY in servers;
+  return servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
 }
 
 function claudeDesktopInstall(): void {


### PR DESCRIPTION
## Problem

`npm run lint` fails with:

```
server/integrations/client-config.ts
  47:18  error  Expected '!==' and instead saw '!='  eqeqeq
```

## Root Cause

`claudeDesktopDetect()` uses the loose inequality operator `!= null` to guard the `in` expression:

```ts
return servers != null && ASSISTMEM_SERVER_KEY in servers;
```

The project's ESLint config enforces the `eqeqeq` rule (strict equality everywhere), so loose `!=`/`==` are errors. A naive replacement with `!== null` would be incorrect: `servers` is typed as `Record<string, unknown> | undefined` (never `null`), so an `undefined` value would pass the `!== null` check and then throw a `TypeError` inside the `in` expression.

## The Fix

Changed the guard to `!== undefined`, which is accurate for the actual type and passes the lint rule:

```ts
return servers !== undefined && ASSISTMEM_SERVER_KEY in servers;
```

## Verification

All checks pass after the change:

- `npm run typecheck` — ✅ no errors
- `npm run lint` — ✅ no errors
- `npm test` — ✅ 400 tests, 0 failures
- `npm run build` — ✅ builds successfully

## Potential Risks / Side Effects

Behaviorally equivalent: `servers` is only ever `undefined` (never `null`) based on its TypeScript type and the `readJsonConfig` return type, so the guard change has no observable runtime difference.